### PR TITLE
doct--warn-template-entry-type-maybe: fix entry validation

### DIFF
--- a/doct.el
+++ b/doct.el
@@ -7,7 +7,7 @@
 ;; Created: December 10, 2019
 ;; Keywords: org, convenience
 ;; Package-Requires: ((emacs "25.1"))
-;; Version: 3.1.8
+;; Version: 3.1.9
 
 ;; This file is not part of GNU Emacs.
 
@@ -466,8 +466,7 @@ Retrun AFTER form."
                 (string-prefix-p "%[" trimmed))
       (pcase (doct--entry-type)
         ('entry
-         (unless (or (string-prefix-p "* " trimmed)
-                     (equal trimmed "*"))
+         (unless (string-match-p "\\(?:^\\*+\\)" trimmed)
            (doct--warn  'template-entry-type
                         (concat "expanded :template %S in the %S declaration "
                                 "is not a valid Org entry.\n"


### PR DESCRIPTION
string-prefix-p does not check via regular expressions.
Even if it did, multiple leading asterisks need to be accounted for.

<!-- Please create pull requests against the development branch -->
